### PR TITLE
Fix import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/BlacklightOPAC/BlacklightOPAC.lua
+++ b/BlacklightOPAC/BlacklightOPAC.lua
@@ -200,9 +200,9 @@ function ImportTerms()
     --outstr = outstr .. "\r\nerr = " .. tostring(err); 
     Log("Blacklight OPAC response data: " .. response );
     local src= string.match(response, "<h3(.+)</h3>.* class=.description.");
-    Log("Blacklight OPAC h4 data: " .. src );
+    Log("Blacklight OPAC src data: " .. src );
     local desc = string.match(src,"<a.*>(.*)</a>");
-    Log("Blacklight OPAC response data: " .. desc );
+    Log("Blacklight OPAC desc data: " .. desc );
     outstr = outstr .. "\r\nSource:\t" .. desc; 
     local tab = string.match(response, '<table%s+class=".+">(.+)</table>');
     tab = string.gsub(tab,"<tr>","\n\r");
@@ -211,7 +211,9 @@ function ImportTerms()
     tab = string.gsub(tab,"</th>","");
     tab = string.gsub(tab,"<td>","\t");
     tab = string.gsub(tab,"</td>","");
-    tab = string.gsub(tab,"^    ","");
+    tab = string.gsub(tab,"</tbody>","");
+    tab = string.gsub(tab,"</thead>","");
+    tab = string.gsub(tab,"<tbody>","");
     outstr = outstr .. "\r\nLocal Terms of Use: " .. tab; 
 
   end

--- a/BlacklightOPAC/BlacklightOPAC.lua
+++ b/BlacklightOPAC/BlacklightOPAC.lua
@@ -52,6 +52,7 @@ function Init()
   opacForm.TouInfo.Value = "Fill in later"; 
   opacForm.JournalInfo = opacForm.Form:CreateMemoEdit("Journal Info", "JournalInfo");
   processType = GetFieldValue("Transaction", "ProcessType");
+  Log("Blacklight OPAC process type = " .. processType);
   if processType == "Lending" then
     opacForm.Form:LoadLayout("BlacklightOPACLendlayout.xml");
   elseif processType == "Doc Del" then
@@ -178,10 +179,10 @@ function ImportTerms()
   local otext = obrowser.DocumentText;
   local n = 1;
   local matches = {};
-  for w in string.gfind(otext, "/catalog/tou/%d+/%u+/%w+.>Terms") do
+  for w in string.gfind(otext, "/catalog/tou/%d+/%u+/%w+%\">Terms") do
     local term  = {};
     Log("Blacklight OPAC w = " .. w );
-    local id,m1,m2 = string.match(w, "/catalog/tou/(%d+)/(%u+)/(%w+).>Terms")
+    local id,m1,m2 = string.match(w, "/catalog/tou/(%d+)/(%u+)/(%w+)%\">Terms")
     term.id = id;
     term.m1 = m1;
     term.m2 = m2;
@@ -197,8 +198,11 @@ function ImportTerms()
     outstr = outstr .. "\r\n***********************************\n\r"; 
     --outstr = outstr .. "\r\r".. c .. "\n\r"; 
     --outstr = outstr .. "\r\nerr = " .. tostring(err); 
-    local h4 = string.match(response, "<h4(.+)</h4>");
-    local desc = string.match(h4,"<a.*>(.*)</a>");
+    Log("Blacklight OPAC response data: " .. response );
+    local src= string.match(response, "<h3(.+)</h3>.* class=.description.");
+    Log("Blacklight OPAC h4 data: " .. src );
+    local desc = string.match(src,"<a.*>(.*)</a>");
+    Log("Blacklight OPAC response data: " .. desc );
     outstr = outstr .. "\r\nSource:\t" .. desc; 
     local tab = string.match(response, '<table%s+class=".+">(.+)</table>');
     tab = string.gsub(tab,"<tr>","\n\r");

--- a/BlacklightOPAC/BlacklightOPAC.lua
+++ b/BlacklightOPAC/BlacklightOPAC.lua
@@ -46,8 +46,6 @@ function Init()
   opacForm.RibbonPage:CreateButton("Search Title",GetClientImage("Search32"),"SearchTitle", "Search");
   opacForm.RibbonPage:CreateButton("Import Info",GetClientImage("ImportData32"),"ImportInfo", "Import");
   opacForm.RibbonPage:CreateButton("Import as E-Resource",GetClientImage("ImportData32"),"ImportElectronic","Import");
-  Log("No longer loading the Import Term button");
-  --opacForm.RibbonPage:CreateButton("Import Terms",GetClientImage("ImportData32"),"ImportTerms","Import");
   opacForm.Browser.WebBrowser.ScriptErrorsSuppressed = true
   opacForm.TouInfo = opacForm.Form:CreateMemoEdit("TOU Info", "TOUInfo");
   opacForm.TouInfo.Value = "Fill in later"; 
@@ -92,7 +90,6 @@ function SearchKeyword()
   end
   searchTerm = stripc(searchTerm,"/:");
   opacForm.Browser:RegisterPageHandler("formExists", "search-form", "OPACLoaded", false);
-  opacForm.Browser:RegisterPageHandler("custom", "TestOPACTerms", "OPAChasTerms", true);
   opacForm.Browser:Navigate(settings.OpacUrl);	
 end
 
@@ -122,102 +119,31 @@ function SearchTitle()
   end
   searchTerm = stripc(searchTerm,"/:");
   opacForm.Browser:RegisterPageHandler("formExists", "search-form", "OPACLoaded", false);
-  opacForm.Browser:RegisterPageHandler("custom", "TestOPACTerms", "OPAChasTerms", true);
   opacForm.Browser:Navigate(settings.OpacUrl);  
 end
 
+-- Called when the 'Search Author' button is clicked
+-- fetch author information from the transaction and then search the catalog for more items by that author
 function SearchAuthor()
   if GetFieldValue("Transaction", "RequestType") == "Loan" then
-    searchTerm = GetFieldValue("Transaction", "LoanTitle");
-    searchCode = "author/creator";
+    searchTerm = GetFieldValue("Transaction", "LoanAuthor");
   else
-    searchTerm = GetFieldValue("Transaction", "PhotoJournalTitle");
+    searchTerm = GetFieldValue("Transaction", "PhotoArticleAuthor");
     opacForm.JournalInfo.Value = searchTerm .. " " .. processType ; 
-    searchCode = "author/creator";
   end
+  searchCode = "author";
   searchTerm = stripc(searchTerm,"/:");
   opacForm.Browser:RegisterPageHandler("formExists", "search-form", "OPACLoaded", false);
-  opacForm.Browser:RegisterPageHandler("custom", "TestOPACTerms", "OPAChasTerms", true);
   opacForm.Browser:Navigate(settings.OpacUrl);  
-end
-
-function OPAChasNoTerms()
- Log("OPAC has No Terms ");
-end
-
-function OPAChasTerms()
- Log("OPAC has Terms ");
-  opacForm.Browser:RegisterPageHandler("custom", "TestOPACTerms", "OPAChasTerms", true);
- ImportTerms();
-end
-
-function TestOPACTerms()
-  opacForm.Browser:RegisterPageHandler("custom", "TestOPACTerms", "OPAChasTerms", true);
-  local obrowser = opacForm.Browser.WebBrowser;	
-  local otext = obrowser.DocumentText;
-  local y = string.find(otext, "/catalog/tou/%d+/%u+/%w+.>Terms");
-   if y == nil then 
-     Log("test OPAC terms : false " .. tostring(y));
-     opacForm.TouInfo.Value = "";
-     return false; 
-  else
-     Log("test OPAC terms : true " .. y);
-     return true; 
-  end
 end
 
 function OPACLoaded()
   Log("SearchTerm = " .. searchTerm );
-  Log("SearchCode = " .. searchCode );
+  Log("**** in OPAC LOADED SearchCode = " .. searchCode );
   opacForm.Browser:SetFormValue("search-form", "q", searchTerm);
   opacForm.Browser:SetFormValue("search-form", "search_field", searchCode);
   opacForm.Browser:SubmitForm("search-form");
 
-end
-
-function ImportTerms()
-  local obrowser = opacForm.Browser.WebBrowser;	
-  local otext = obrowser.DocumentText;
-  local n = 1;
-  local matches = {};
-  for w in string.gfind(otext, "/catalog/tou/%d+/%u+/%w+%\">Terms") do
-    local term  = {};
-    Log("Blacklight OPAC w = " .. w );
-    local id,m1,m2 = string.match(w, "/catalog/tou/(%d+)/(%u+)/(%w+)%\">Terms")
-    term.id = id;
-    term.m1 = m1;
-    term.m2 = m2;
-    matches[n] = term;  
-    n = n +1;
-  end
-  local outstr = "";
-  for c=1,#matches do
-    local term = matches[c];
-    local url = catalog_tou_url .. "/" .. term.id .. "/" .. term.m1 .. "/" .. term.m2;
-    Log("Blacklight OPAC tou url " .. url );
-    local err,response = pcall( function ()  return wclient:DownloadString(url); end ); 
-    outstr = outstr .. "\r\n***********************************\n\r"; 
-    outstr = outstr .. "\r\r".. c .. "\n\r"; 
-    outstr = outstr .. "\r\nerr = " .. tostring(err); 
-    Log("Blacklight OPAC tou possible error" .. outstr);
-    Log("Blacklight OPAC response data: " .. response );
-    local src= string.match(response, "<h3(.+)</h3>.* class=.description.");
-    Log("Blacklight OPAC h4 data: " .. src );
-    local desc = string.match(src,"<a.*>(.*)</a>");
-    Log("Blacklight OPAC response data: " .. desc );
-    outstr = outstr .. "\r\nSource:\t" .. desc; 
-    local tab = string.match(response, '<table%s+class=".+">(.+)</table>');
-    tab = string.gsub(tab,"<tr>","\n\r");
-    tab = string.gsub(tab,"</tr>","");
-    tab = string.gsub(tab,"<th>","\t");
-    tab = string.gsub(tab,"</th>","");
-    tab = string.gsub(tab,"<td>","\t");
-    tab = string.gsub(tab,"</td>","");
-    tab = string.gsub(tab,"^    ","");
-    outstr = outstr .. "\r\nLocal Terms of Use: " .. tab; 
-
-  end
-  opacForm.TouInfo.Value = outstr;
 end
 
 function ImportElectronic()
@@ -238,6 +164,10 @@ function ImportInfo()
   local locstr = "";
   local calstr = "";
   local doc_id = string.match(obrowser.DocumentText, "/catalog/(%d+)/citation");
+  if doc_id == nil then
+    -- Import Info btn was clicked on results page, not on item detail page, so skip import
+    return;
+  end
   -- the first table should not be the rare table.
   -- local detailsTable = opacForm.Browser:GetElementByCollectionIndex(document:GetElementsByTagName("table"), 0);
   local divs = document:GetElementsByTagName("div");

--- a/BlacklightOPAC/BlacklightOPAC.lua
+++ b/BlacklightOPAC/BlacklightOPAC.lua
@@ -46,7 +46,8 @@ function Init()
   opacForm.RibbonPage:CreateButton("Search Title",GetClientImage("Search32"),"SearchTitle", "Search");
   opacForm.RibbonPage:CreateButton("Import Info",GetClientImage("ImportData32"),"ImportInfo", "Import");
   opacForm.RibbonPage:CreateButton("Import as E-Resource",GetClientImage("ImportData32"),"ImportElectronic","Import");
-  opacForm.RibbonPage:CreateButton("Import Terms",GetClientImage("ImportData32"),"ImportTerms","Import");
+  Log("No longer loading the Import Term button");
+  --opacForm.RibbonPage:CreateButton("Import Terms",GetClientImage("ImportData32"),"ImportTerms","Import");
   opacForm.Browser.WebBrowser.ScriptErrorsSuppressed = true
   opacForm.TouInfo = opacForm.Form:CreateMemoEdit("TOU Info", "TOUInfo");
   opacForm.TouInfo.Value = "Fill in later"; 
@@ -54,9 +55,9 @@ function Init()
   processType = GetFieldValue("Transaction", "ProcessType");
   Log("Blacklight OPAC process type = " .. processType);
   if processType == "Lending" then
-    opacForm.Form:LoadLayout("BlacklightOPACLendlayout.xml");
+    opacForm.Form:LoadLayout("BlacklightOPACBorrowlayout.xml");
   elseif processType == "Doc Del" then
-    opacForm.Form:LoadLayout("BlacklightOPACLendlayout.xml");
+    opacForm.Form:LoadLayout("BlacklightOPACBorrowlayout.xml");
   else 
     opacForm.Form:LoadLayout("BlacklightOPACBorrowlayout.xml");
   end
@@ -196,13 +197,14 @@ function ImportTerms()
     Log("Blacklight OPAC tou url " .. url );
     local err,response = pcall( function ()  return wclient:DownloadString(url); end ); 
     outstr = outstr .. "\r\n***********************************\n\r"; 
-    --outstr = outstr .. "\r\r".. c .. "\n\r"; 
-    --outstr = outstr .. "\r\nerr = " .. tostring(err); 
+    outstr = outstr .. "\r\r".. c .. "\n\r"; 
+    outstr = outstr .. "\r\nerr = " .. tostring(err); 
+    Log("Blacklight OPAC tou possible error" .. outstr);
     Log("Blacklight OPAC response data: " .. response );
     local src= string.match(response, "<h3(.+)</h3>.* class=.description.");
-    Log("Blacklight OPAC src data: " .. src );
+    Log("Blacklight OPAC h4 data: " .. src );
     local desc = string.match(src,"<a.*>(.*)</a>");
-    Log("Blacklight OPAC desc data: " .. desc );
+    Log("Blacklight OPAC response data: " .. desc );
     outstr = outstr .. "\r\nSource:\t" .. desc; 
     local tab = string.match(response, '<table%s+class=".+">(.+)</table>');
     tab = string.gsub(tab,"<tr>","\n\r");
@@ -211,9 +213,7 @@ function ImportTerms()
     tab = string.gsub(tab,"</th>","");
     tab = string.gsub(tab,"<td>","\t");
     tab = string.gsub(tab,"</td>","");
-    tab = string.gsub(tab,"</tbody>","");
-    tab = string.gsub(tab,"</thead>","");
-    tab = string.gsub(tab,"<tbody>","");
+    tab = string.gsub(tab,"^    ","");
     outstr = outstr .. "\r\nLocal Terms of Use: " .. tab; 
 
   end
@@ -247,7 +247,7 @@ function ImportInfo()
   end
   for i=0,divs.Count - 1 do
     local elem = opacForm.Browser:GetElementByCollectionIndex(divs, i);
-    if elem.ParentNode ~= nil then
+    -- if elem.ParentNode ~= nil then
       if elem:GetAttribute("className")=="holding" then
         local holdRows = elem.Children; 
         Log("Blacklight OPAC Found " .. holdRows.Count .. " divs.");
@@ -256,11 +256,11 @@ function ImportInfo()
         local caltd = opacForm.Browser:GetElementByCollectionIndex(holdRows, 1);
         Log("Blacklight OPAC loc Text: " .. loctd.InnerText);
         Log("Blacklight OPAC cal Text: " .. caltd.InnerText);
-        locstr=string.sub(loctd.InnerText,1,string.len(loctd.InnerText)-12);
-        calstr=string.sub(caltd.InnerText,1,string.len(caltd.InnerText)-8);
-	break
+        locstr=string.sub(loctd.InnerText,1,string.len(loctd.InnerText)-8);
+        calstr=string.sub(caltd.InnerText,1,string.len(caltd.InnerText));
+	      break
       end 
-    end
+    -- end
   end
   --
   -- in the first holding div, there are two divs, class location, class call-number

--- a/BlacklightOPAC/BlacklightOPAC.lua
+++ b/BlacklightOPAC/BlacklightOPAC.lua
@@ -46,23 +46,25 @@ function Init()
   opacForm.RibbonPage:CreateButton("Search Title",GetClientImage("Search32"),"SearchTitle", "Search");
   opacForm.RibbonPage:CreateButton("Import Info",GetClientImage("ImportData32"),"ImportInfo", "Import");
   opacForm.RibbonPage:CreateButton("Import as E-Resource",GetClientImage("ImportData32"),"ImportElectronic","Import");
+  opacForm.RibbonPage:CreateButton("Open New Browser", GetClientImage("Web32"), "OpenInDefaultBrowser", "Utility");
   opacForm.Browser.WebBrowser.ScriptErrorsSuppressed = true
   opacForm.TouInfo = opacForm.Form:CreateMemoEdit("TOU Info", "TOUInfo");
   opacForm.TouInfo.Value = "Fill in later"; 
   opacForm.JournalInfo = opacForm.Form:CreateMemoEdit("Journal Info", "JournalInfo");
   processType = GetFieldValue("Transaction", "ProcessType");
-  Log("Blacklight OPAC process type = " .. processType);
-  if processType == "Lending" then
-    opacForm.Form:LoadLayout("BlacklightOPACBorrowlayout.xml");
-  elseif processType == "Doc Del" then
-    opacForm.Form:LoadLayout("BlacklightOPACBorrowlayout.xml");
-  else 
-    opacForm.Form:LoadLayout("BlacklightOPACBorrowlayout.xml");
-  end
+  opacForm.Form:LoadLayout("BlacklightOPACBorrowlayout.xml");
   opacForm.TouInfo.Value = "Fill in later:" .. processType; 
   opacForm.Form:Show();
   SearchTitle();
-  Log("FIRST DEBUG MESSAGE FROM Blacklight OPAC ");
+end
+
+-- Open New Browser button 
+function OpenInDefaultBrowser()
+  local currentUrl = opacForm.Browser.Address;
+  if (currentUrl and currentUrl ~= "") then
+      LogDebug("Opening Browser URL in default browser: " .. currentUrl);
+      os.execute('start "" "' .. currentUrl .. '"');
+  end
 end
 
 function SearchKeyword()

--- a/BlacklightOPAC/BlacklightOPAC.lua
+++ b/BlacklightOPAC/BlacklightOPAC.lua
@@ -150,8 +150,8 @@ end
 
 function ImportElectronic()
   local obrowser = opacForm.Browser.WebBrowser;
-  local doc_id = string.match(obrowser.DocumentText, "/catalog/(%d+)/citation");
-  SetFieldValue("Transaction", "Location", "Olin LIbrary");
+  local doc_id = string.match(obrowser.DocumentText, "/catalog/(%d+)/librarian_view");
+  SetFieldValue("Transaction", "Location", "Olin Library");
   SetFieldValue("Transaction", "CallNumber", "*Networked Resource");
   Log("Blacklight OPAC WebBrowser docid: " .. doc_id);
   SetFieldValue("Transaction","ItemInfo5",settings.OpacUrl .. "/catalog/" .. doc_id);
@@ -165,7 +165,7 @@ function ImportInfo()
   local url = obrowser.Url;
   local locstr = "";
   local calstr = "";
-  local doc_id = string.match(obrowser.DocumentText, "/catalog/(%d+)/citation");
+  local doc_id = string.match(obrowser.DocumentText, "/catalog/(%d+)/librarian_view");
   if doc_id == nil then
     -- Import Info btn was clicked on results page, not on item detail page, so skip import
     return;

--- a/BlacklightOPAC/Config.xml
+++ b/BlacklightOPAC/Config.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>Blacklight OPAC Search</Name>
-  <Author>Nooogon,Inc.</Author>
-  <Version>1.3</Version>
+  <Author>Nooogon,Inc.; updated by Rick Silterra, John Cline, Matthew Connolly</Author>
+  <Version>1.5</Version>
   <Active>True</Active>
   <Type>Addon</Type>
   <Description>Performs a Blacklight OPAC title search with option for a keyword search as well. Once on a results page, Import Info will copy the call number and location values.</Description>

--- a/BlacklightOPAC/Config.xml
+++ b/BlacklightOPAC/Config.xml
@@ -2,8 +2,8 @@
 <Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>Blacklight OPAC Search</Name>
-  <Author>Nooogon,Inc.; updated by Rick Silterra, John Cline, Matthew Connolly</Author>
-  <Version>1.5</Version>
+  <Author>Nooogon,Inc.; updated by Rick Silterra, John Cline, Matthew Connolly, Sarah Chintomby</Author>
+  <Version>1.5.1</Version>
   <Active>True</Active>
   <Type>Addon</Type>
   <Description>Performs a Blacklight OPAC title search with option for a keyword search as well. Once on a results page, Import Info will copy the call number and location values.</Description>
@@ -11,7 +11,7 @@
     <Form>FormRequest</Form>
   </Forms>
   <Settings>
-    <Setting name="OPACURL" value="http://newcatalog.library.cornell.edu" type="string">
+    <Setting name="OPACURL" value="http://catalog.library.cornell.edu" type="string">
       <Description>The URL for your Blacklight OPAC. (i.e. http://catalog.princeton.edu)</Description>
     </Setting>
   </Settings>


### PR DESCRIPTION
The import button broke after an update to Blacklight that removed the citation export feature. The /citation link was being used as a test of whether the add-on was looking at an item record page. The librarian_view link should provide a more stable page component to test against.

This PR also updates version and project metadata.